### PR TITLE
chore: removing node7 job from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 unit_tests:
-  steps: &ref_0
+  steps: &unit_tests
     - checkout
     - run:
         name: Install modules and dependencies.
@@ -98,17 +98,17 @@ jobs:
     docker:
       - image: 'node:6'
         user: node
-    steps: *ref_0
+    steps: *unit_tests
   node8:
     docker:
       - image: 'node:8'
         user: node
-    steps: *ref_0
+    steps: *unit_tests
   node9:
     docker:
       - image: 'node:9'
         user: node
-    steps: *ref_0
+    steps: *unit_tests
   lint:
     docker:
       - image: 'node:8'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
----
-# "Include" for unit tests definition.
-unit_tests: &unit_tests
-  steps:
+unit_tests:
+  steps: &ref_0
     - checkout
     - run:
         name: Install modules and dependencies.
@@ -13,8 +11,7 @@ unit_tests: &unit_tests
         name: Submit coverage data to codecov.
         command: node_modules/.bin/codecov
         when: always
-
-version: 2.0
+version: 2
 workflows:
   version: 2
   tests:
@@ -24,10 +21,6 @@ workflows:
             tags:
               only: /.*/
       - node6:
-          filters:
-            tags:
-              only: /.*/
-      - node7:
           filters:
             tags:
               only: /.*/
@@ -43,7 +36,6 @@ workflows:
           requires:
             - node4
             - node6
-            - node7
             - node8
             - node9
           filters:
@@ -53,7 +45,6 @@ workflows:
           requires:
             - node4
             - node6
-            - node7
             - node8
             - node9
           filters:
@@ -67,7 +58,7 @@ workflows:
             branches:
               only: master
             tags:
-              only: /^v[\d.]+$/
+              only: '/^v[\d.]+$/'
       - sample_tests:
           requires:
             - lint
@@ -76,7 +67,7 @@ workflows:
             branches:
               only: master
             tags:
-              only: /^v[\d.]+$/
+              only: '/^v[\d.]+$/'
       - publish_npm:
           requires:
             - system_tests
@@ -85,12 +76,11 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[\d.]+$/
-
+              only: '/^v[\d.]+$/'
 jobs:
   node4:
     docker:
-      - image: node:4
+      - image: 'node:4'
         user: node
     steps:
       - checkout
@@ -106,28 +96,22 @@ jobs:
           when: always
   node6:
     docker:
-      - image: node:6
+      - image: 'node:6'
         user: node
-    <<: *unit_tests
-  node7:
-    docker:
-      - image: node:7
-        user: node
-    <<: *unit_tests
+    steps: *ref_0
   node8:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
-    <<: *unit_tests
+    steps: *ref_0
   node9:
     docker:
-      - image: node:9
+      - image: 'node:9'
         user: node
-    <<: *unit_tests
-
+    steps: *ref_0
   lint:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -153,10 +137,9 @@ jobs:
           command: npm run lint
           environment:
             NPM_CONFIG_PREFIX: /home/node/.npm-global
-
   docs:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -166,10 +149,9 @@ jobs:
       - run:
           name: Build documentation.
           command: npm run docs
-
   sample_tests:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -208,10 +190,9 @@ jobs:
           command: rm .circleci/key.json
           when: always
     working_directory: /home/node/dlp-samples
-
   system_tests:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
@@ -233,16 +214,15 @@ jobs:
           name: Remove unencrypted key.
           command: rm .circleci/key.json
           when: always
-
   publish_npm:
     docker:
-      - image: node:8
+      - image: 'node:8'
         user: node
     steps:
       - checkout
       - run:
           name: Set NPM authentication.
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          command: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc'
       - run:
-         name: Publish the module to npm.
-         command: npm publish
+          name: Publish the module to npm.
+          command: npm publish


### PR DESCRIPTION
We don't need to test on Node 7 anymore. Note: no action is required for this PR for now.