### PR TITLE
Fix dlp code sample end/start tags for embedding

### DIFF
--- a/samples/deid.js
+++ b/samples/deid.js
@@ -234,7 +234,7 @@ function deidentifyWithDateShift(
     .catch(err => {
       console.log(`Error in deidentifyWithDateShift: ${err.message || err}`);
     });
-  // [END deidentify_date_shift]
+  // [END dlp_deidentify_date_shift]
 }
 
 function deidentifyWithFpe(
@@ -319,7 +319,7 @@ function deidentifyWithFpe(
     .catch(err => {
       console.log(`Error in deidentifyWithFpe: ${err.message || err}`);
     });
-  // [END deidentify_fpe]
+  // [END dlp_deidentify_fpe]
 }
 
 function reidentifyWithFpe(


### PR DESCRIPTION
Fix mismatched tags breaking embedding of code samples on cloud.google.com/dlp/docs.

- [x ] Tests and linter pass
- [x ] Code coverage does not decrease (if any source code was changed)
- [x ] Appropriate docs were updated (if necessary)
