### PR TITLE
fix: requiring samples/ node engine >7.6 because async/await was used

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -7,7 +7,7 @@
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-dlp",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=7.6"
   },
   "scripts": {
     "test": "ava -T 5m --verbose system-test/*.test.js"

--- a/samples/package.json
+++ b/samples/package.json
@@ -7,7 +7,7 @@
   "author": "Google Inc.",
   "repository": "googleapis/nodejs-dlp",
   "engines": {
-    "node": ">=7.6"
+    "node": ">=8"
   },
   "scripts": {
     "test": "ava -T 5m --verbose system-test/*.test.js"


### PR DESCRIPTION
This should help get #61 passing.

But are we ready to bring in node>6 features into our repos yet, given that we still support node6?