### PR TITLE
refactor(samples): convert sample tests from ava to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fix": "eslint --fix '**/*.js' && npm run prettier"
   },
   "dependencies": {
-    "google-gax": "^0.20.0",
+    "google-gax": "^0.22.0",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"
   },

--- a/samples/deid.js
+++ b/samples/deid.js
@@ -520,7 +520,7 @@ const cli = require(`yargs`)
         opts.contextFieldId,
         opts.wrappedKey,
         opts.keyName
-      )
+      ).catch(console.log)
   )
   .option('c', {
     type: 'string',

--- a/samples/package.json
+++ b/samples/package.json
@@ -10,7 +10,7 @@
     "node": ">=8"
   },
   "scripts": {
-    "test": "ava -T 5m --verbose system-test/*.test.js"
+    "test": "mocha system-test/*.test.js --timeout=600000"
   },
   "dependencies": {
     "@google-cloud/dlp": "0.9.0",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@google-cloud/nodejs-repo-tools": "^3.0.0",
-    "ava": "^0.25.0",
+    "mocha": "^5.2.0",
     "pixelmatch": "^4.0.2",
     "pngjs": "^3.3.3",
     "uuid": "^3.3.2"

--- a/samples/system-test/.eslintrc.yml
+++ b/samples/system-test/.eslintrc.yml
@@ -1,5 +1,6 @@
 ---
+env:
+  mocha: true
 rules:
   node/no-unpublished-require: off
-  node/no-unsupported-features: off
   no-empty: off

--- a/samples/system-test/deid.test.js
+++ b/samples/system-test/deid.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/deid.test.js
+++ b/samples/system-test/deid.test.js
@@ -16,12 +16,12 @@
 'use strict';
 
 const path = require('path');
-const test = require('ava');
+const assert = require('assert');
 const fs = require('fs');
 const tools = require('@google-cloud/nodejs-repo-tools');
 
 const cmd = 'node deid.js';
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, '..');
 
 const harmfulString = 'My SSN is 372819127';
 const harmlessString = 'My favorite color is blue';
@@ -32,112 +32,122 @@ let labeledFPEString;
 const wrappedKey = process.env.DLP_DEID_WRAPPED_KEY;
 const keyName = process.env.DLP_DEID_KEY_NAME;
 
-const csvFile = `resources/dates.csv`;
-const tempOutputFile = path.join(__dirname, `temp.result.csv`);
-const csvContextField = `name`;
+const csvFile = 'resources/dates.csv';
+const tempOutputFile = path.join(__dirname, 'temp.result.csv');
+const csvContextField = 'name';
 const dateShiftAmount = 30;
-const dateFields = `birth_date register_date`;
+const dateFields = 'birth_date register_date';
 
-test.before(tools.checkCredentials);
+before(tools.checkCredentials);
 
 // deidentify_masking
-test(`should mask sensitive data in a string`, async t => {
+it('should mask sensitive data in a string', async () => {
   const output = await tools.runAsync(
     `${cmd} deidMask "${harmfulString}" -m x -n 5`,
     cwd
   );
-  t.is(output, 'My SSN is xxxxx9127');
+  assert.strictEqual(output, 'My SSN is xxxxx9127');
 });
 
-test(`should ignore insensitive data when masking a string`, async t => {
+it('should ignore insensitive data when masking a string', async () => {
   const output = await tools.runAsync(
     `${cmd} deidMask "${harmlessString}"`,
     cwd
   );
-  t.is(output, harmlessString);
+  assert.strictEqual(output, harmlessString);
 });
 
-test(`should handle masking errors`, async t => {
+it('should handle masking errors', async () => {
   const output = await tools.runAsync(
     `${cmd} deidMask "${harmfulString}" -n -1`,
     cwd
   );
-  t.regex(output, /Error in deidentifyWithMask/);
+  assert.strictEqual(
+    new RegExp(/Error in deidentifyWithMask/).test(output),
+    true
+  );
 });
 
 // deidentify_fpe
-test(`should FPE encrypt sensitive data in a string`, async t => {
+it('should FPE encrypt sensitive data in a string', async () => {
   const output = await tools.runAsync(
     `${cmd} deidFpe "${harmfulString}" ${wrappedKey} ${keyName} -a NUMERIC`,
     cwd
   );
-  t.regex(output, /My SSN is \d{9}/);
-  t.not(output, harmfulString);
+  assert.strictEqual(new RegExp(/My SSN is \d{9}/).test(output), true);
+  assert.notStrictEqual(output, harmfulString);
 });
 
-test.serial(`should use surrogate info types in FPE encryption`, async t => {
+it('should use surrogate info types in FPE encryption', async () => {
   const output = await tools.runAsync(
     `${cmd} deidFpe "${harmfulString}" ${wrappedKey} ${keyName} -a NUMERIC -s ${surrogateType}`,
     cwd
   );
-  t.regex(output, /My SSN is SSN_TOKEN\(9\):\d{9}/);
+  assert.strictEqual(
+    new RegExp(/My SSN is SSN_TOKEN\(9\):\d{9}/).test(output),
+    true
+  );
   labeledFPEString = output;
 });
 
-test(`should ignore insensitive data when FPE encrypting a string`, async t => {
+it('should ignore insensitive data when FPE encrypting a string', async () => {
   const output = await tools.runAsync(
     `${cmd} deidFpe "${harmlessString}" ${wrappedKey} ${keyName}`,
     cwd
   );
-  t.is(output, harmlessString);
+  assert.strictEqual(output, harmlessString);
 });
 
-test(`should handle FPE encryption errors`, async t => {
+it('should handle FPE encryption errors', async () => {
   const output = await tools.runAsync(
     `${cmd} deidFpe "${harmfulString}" ${wrappedKey} BAD_KEY_NAME`,
     cwd
   );
-  t.regex(output, /Error in deidentifyWithFpe/);
+  assert.strictEqual(
+    new RegExp(/Error in deidentifyWithFpe/).test(output),
+    true
+  );
 });
 
 // reidentify_fpe
-test.serial(
-  `should FPE decrypt surrogate-typed sensitive data in a string`,
-  async t => {
-    t.truthy(labeledFPEString, `Verify that FPE encryption succeeded.`);
-    const output = await tools.runAsync(
-      `${cmd} reidFpe "${labeledFPEString}" ${surrogateType} ${wrappedKey} ${keyName} -a NUMERIC`,
-      cwd
-    );
-    t.is(output, harmfulString);
-  }
-);
+it('should FPE decrypt surrogate-typed sensitive data in a string', async () => {
+  assert.ok(labeledFPEString, 'Verify that FPE encryption succeeded.');
+  const output = await tools.runAsync(
+    `${cmd} reidFpe "${labeledFPEString}" ${surrogateType} ${wrappedKey} ${keyName} -a NUMERIC`,
+    cwd
+  );
+  assert.strictEqual(output, harmfulString);
+});
 
-test(`should handle FPE decryption errors`, async t => {
+it('should handle FPE decryption errors', async () => {
   const output = await tools.runAsync(
     `${cmd} reidFpe "${harmfulString}" ${surrogateType} ${wrappedKey} BAD_KEY_NAME -a NUMERIC`,
     cwd
   );
-  t.regex(output, /Error in reidentifyWithFpe/);
+  assert.strictEqual(
+    new RegExp(/Error in reidentifyWithFpe/).test(output),
+    true
+  );
 });
 
 // deidentify_date_shift
-test(`should date-shift a CSV file`, async t => {
+it('should date-shift a CSV file', async () => {
   const outputCsvFile = 'dates.actual.csv';
   const output = await tools.runAsync(
     `${cmd} deidDateShift "${csvFile}" "${outputCsvFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields}`,
     cwd
   );
-  t.true(
-    output.includes(`Successfully saved date-shift output to ${outputCsvFile}`)
+  assert.strictEqual(
+    output.includes(`Successfully saved date-shift output to ${outputCsvFile}`),
+    true
   );
-  t.not(
+  assert.notStrictEqual(
     fs.readFileSync(outputCsvFile).toString(),
     fs.readFileSync(csvFile).toString()
   );
 });
 
-test(`should date-shift a CSV file using a context field`, async t => {
+it('should date-shift a CSV file using a context field', async () => {
   const outputCsvFile = 'dates-context.actual.csv';
   const expectedCsvFile =
     'system-test/resources/date-shift-context.expected.csv';
@@ -145,17 +155,18 @@ test(`should date-shift a CSV file using a context field`, async t => {
     `${cmd} deidDateShift "${csvFile}" "${outputCsvFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName} -w ${wrappedKey}`,
     cwd
   );
-  t.true(
-    output.includes(`Successfully saved date-shift output to ${outputCsvFile}`)
+  assert.strictEqual(
+    output.includes(`Successfully saved date-shift output to ${outputCsvFile}`),
+    true
   );
-  t.is(
+  assert.strictEqual(
     fs.readFileSync(outputCsvFile).toString(),
     fs.readFileSync(expectedCsvFile).toString()
   );
 });
 
-test(`should require all-or-none of {contextField, wrappedKey, keyName}`, async t => {
-  await t.throws(
+it('should require all-or-none of {contextField, wrappedKey, keyName}', async () => {
+  await assert.throws(
     tools.runAsync(
       `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName}`,
       cwd
@@ -165,10 +176,13 @@ test(`should require all-or-none of {contextField, wrappedKey, keyName}`, async 
   );
 });
 
-test(`should handle date-shift errors`, async t => {
+it('should handle date-shift errors', async () => {
   const output = await tools.runAsync(
     `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount}`,
     cwd
   );
-  t.regex(output, /Error in deidentifyWithDateShift/);
+  assert.strictEqual(
+    new RegExp(/Error in deidentifyWithDateShift/).test(output),
+    true
+  );
 });

--- a/samples/system-test/deid.test.js
+++ b/samples/system-test/deid.test.js
@@ -167,10 +167,11 @@ it('should date-shift a CSV file using a context field', async () => {
 
 it('should require all-or-none of {contextField, wrappedKey, keyName}', async () => {
   await assert.throws(
-    () => tools.runAsync(
-      `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName}`,
-      cwd
-    ),
+    () =>
+      tools.runAsync(
+        `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName}`,
+        cwd
+      ),
     Error,
     /You must set either ALL or NONE of/
   );

--- a/samples/system-test/deid.test.js
+++ b/samples/system-test/deid.test.js
@@ -166,14 +166,14 @@ it('should date-shift a CSV file using a context field', async () => {
 });
 
 it('should require all-or-none of {contextField, wrappedKey, keyName}', async () => {
-  await assert.throws(
-    () =>
-      tools.runAsync(
-        `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName}`,
-        cwd
-      ),
-    Error,
-    /You must set either ALL or NONE of/
+  const output = await tools.runAsync(
+    `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName}`,
+    cwd
+  );
+
+  assert.strictEqual(
+    output.includes('You must set either ALL or NONE of'),
+    true
   );
 });
 

--- a/samples/system-test/deid.test.js
+++ b/samples/system-test/deid.test.js
@@ -167,12 +167,12 @@ it('should date-shift a CSV file using a context field', async () => {
 
 it('should require all-or-none of {contextField, wrappedKey, keyName}', async () => {
   await assert.throws(
-    tools.runAsync(
+    () => tools.runAsync(
       `${cmd} deidDateShift "${csvFile}" "${tempOutputFile}" ${dateShiftAmount} ${dateShiftAmount} ${dateFields} -f ${csvContextField} -n ${keyName}`,
       cwd
     ),
     Error,
-    /You must set ALL or NONE of/
+    /You must set either ALL or NONE of/
   );
 });
 

--- a/samples/system-test/inspect.test.js
+++ b/samples/system-test/inspect.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/inspect.test.js
+++ b/samples/system-test/inspect.test.js
@@ -16,24 +16,23 @@
 'use strict';
 
 const path = require('path');
-const test = require('ava');
+const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
 const PubSub = require('@google-cloud/pubsub');
 const pubsub = new PubSub();
 const uuid = require('uuid');
 
 const cmd = 'node inspect.js';
-const cwd = path.join(__dirname, `..`);
-const bucket = `nodejs-docs-samples-dlp`;
-const dataProject = `nodejs-docs-samples`;
-
-test.before(tools.checkCredentials);
+const cwd = path.join(__dirname, '..');
+const bucket = 'nodejs-docs-samples-dlp';
+const dataProject = 'nodejs-docs-samples';
 
 // Create new custom topic/subscription
 let topic, subscription;
 const topicName = `dlp-inspect-topic-${uuid.v4()}`;
 const subscriptionName = `dlp-inspect-subscription-${uuid.v4()}`;
-test.before(async () => {
+before(async () => {
+  tools.checkCredentials();
   await pubsub
     .createTopic(topicName)
     .then(response => {
@@ -46,147 +45,166 @@ test.before(async () => {
 });
 
 // Delete custom topic/subscription
-test.after.always(async () => {
-  await subscription.delete().then(() => topic.delete());
-});
+after(async () => await subscription.delete().then(() => topic.delete()));
 
 // inspect_string
-test(`should inspect a string`, async t => {
+it('should inspect a string', async () => {
   const output = await tools.runAsync(
     `${cmd} string "I'm Gary and my email is gary@example.com"`,
     cwd
   );
-  t.regex(output, /Info type: EMAIL_ADDRESS/);
+  assert.strictEqual(new RegExp(/Info type: EMAIL_ADDRESS/).test(output), true);
 });
 
-test(`should handle a string with no sensitive data`, async t => {
+it('should handle a string with no sensitive data', async () => {
   const output = await tools.runAsync(`${cmd} string "foo"`, cwd);
-  t.is(output, 'No findings.');
+  assert.strictEqual(output, 'No findings.');
 });
 
-test(`should report string inspection handling errors`, async t => {
+it('should report string inspection handling errors', async () => {
   const output = await tools.runAsync(
     `${cmd} string "I'm Gary and my email is gary@example.com" -t BAD_TYPE`,
     cwd
   );
-  t.regex(output, /Error in inspectString/);
+  assert.strictEqual(new RegExp(/Error in inspectString/).test(output), true);
 });
 
 // inspect_file
-test(`should inspect a local text file`, async t => {
+it('should inspect a local text file', async () => {
   const output = await tools.runAsync(`${cmd} file resources/test.txt`, cwd);
-  t.regex(output, /Info type: PHONE_NUMBER/);
-  t.regex(output, /Info type: EMAIL_ADDRESS/);
+  assert.strictEqual(new RegExp(/Info type: PHONE_NUMBER/).test(output), true);
+  assert.strictEqual(new RegExp(/Info type: EMAIL_ADDRESS/).test(output), true);
 });
 
-test(`should inspect a local image file`, async t => {
+it('should inspect a local image file', async () => {
   const output = await tools.runAsync(`${cmd} file resources/test.png`, cwd);
-  t.regex(output, /Info type: EMAIL_ADDRESS/);
+  assert.strictEqual(new RegExp(/Info type: EMAIL_ADDRESS/).test(output), true);
 });
 
-test(`should handle a local file with no sensitive data`, async t => {
+it('should handle a local file with no sensitive data', async () => {
   const output = await tools.runAsync(
     `${cmd} file resources/harmless.txt`,
     cwd
   );
-  t.regex(output, /No findings/);
+  assert.strictEqual(new RegExp(/No findings/).test(output), true);
 });
 
-test(`should report local file handling errors`, async t => {
+it('should report local file handling errors', async () => {
   const output = await tools.runAsync(
     `${cmd} file resources/harmless.txt -t BAD_TYPE`,
     cwd
   );
-  t.regex(output, /Error in inspectFile/);
+  assert.strictEqual(new RegExp(/Error in inspectFile/).test(output), true);
 });
 
 // inspect_gcs_file_promise
-test.skip(`should inspect a GCS text file`, async t => {
+it.skip('should inspect a GCS text file', async () => {
   const output = await tools.runAsync(
     `${cmd} gcsFile ${bucket} test.txt ${topicName} ${subscriptionName}`,
     cwd
   );
-  t.regex(output, /Found \d instance\(s\) of infoType PHONE_NUMBER/);
-  t.regex(output, /Found \d instance\(s\) of infoType EMAIL_ADDRESS/);
+  assert.strictEqual(
+    new RegExp(/Found \d instance\(s\) of infoType PHONE_NUMBER/).test(output),
+    true
+  );
+  assert.strictEqual(
+    new RegExp(/Found \d instance\(s\) of infoType EMAIL_ADDRESS/).test(output),
+    true
+  );
 });
 
-test.skip(`should inspect multiple GCS text files`, async t => {
+it.skip('should inspect multiple GCS text files', async () => {
   const output = await tools.runAsync(
     `${cmd} gcsFile ${bucket} "*.txt" ${topicName} ${subscriptionName}`,
     cwd
   );
-  t.regex(output, /Found \d instance\(s\) of infoType PHONE_NUMBER/);
-  t.regex(output, /Found \d instance\(s\) of infoType EMAIL_ADDRESS/);
+  assert.strictEqual(
+    new RegExp(/Found \d instance\(s\) of infoType PHONE_NUMBER/).test(output),
+    true
+  );
+  assert.strictEqual(
+    new RegExp(/Found \d instance\(s\) of infoType EMAIL_ADDRESS/).test(output),
+    true
+  );
 });
 
-test.skip(`should handle a GCS file with no sensitive data`, async t => {
+it.skip('should handle a GCS file with no sensitive data', async () => {
   const output = await tools.runAsync(
     `${cmd} gcsFile ${bucket} harmless.txt ${topicName} ${subscriptionName}`,
     cwd
   );
-  t.regex(output, /No findings/);
+  assert.strictEqual(new RegExp(/No findings/).test(output), true);
 });
 
-test(`should report GCS file handling errors`, async t => {
+it('should report GCS file handling errors', async () => {
   const output = await tools.runAsync(
     `${cmd} gcsFile ${bucket} harmless.txt ${topicName} ${subscriptionName} -t BAD_TYPE`,
     cwd
   );
-  t.regex(output, /Error in inspectGCSFile/);
+  assert.strictEqual(new RegExp(/Error in inspectGCSFile/).test(output), true);
 });
 
 // inspect_datastore
-test.skip(`should inspect Datastore`, async t => {
+it.skip('should inspect Datastore', async () => {
   const output = await tools.runAsync(
     `${cmd} datastore Person ${topicName} ${subscriptionName} --namespaceId DLP -p ${dataProject}`,
     cwd
   );
-  t.regex(output, /Found \d instance\(s\) of infoType EMAIL_ADDRESS/);
+  assert.strictEqual(
+    new RegExp(/Found \d instance\(s\) of infoType EMAIL_ADDRESS/).test(output),
+    true
+  );
 });
 
-test.skip(`should handle Datastore with no sensitive data`, async t => {
+it.skip('should handle Datastore with no sensitive data', async () => {
   const output = await tools.runAsync(
     `${cmd} datastore Harmless ${topicName} ${subscriptionName} --namespaceId DLP -p ${dataProject}`,
     cwd
   );
-  t.regex(output, /No findings/);
+  assert.strictEqual(new RegExp(/No findings/).test(output), true);
 });
 
-test(`should report Datastore errors`, async t => {
+it('should report Datastore errors', async () => {
   const output = await tools.runAsync(
     `${cmd} datastore Harmless ${topicName} ${subscriptionName} --namespaceId DLP -t BAD_TYPE -p ${dataProject}`,
     cwd
   );
-  t.regex(output, /Error in inspectDatastore/);
+  assert.strictEqual(
+    new RegExp(/Error in inspectDatastore/).test(output),
+    true
+  );
 });
 
 // inspect_bigquery
-test.skip(`should inspect a Bigquery table`, async t => {
+it.skip('should inspect a Bigquery table', async () => {
   const output = await tools.runAsync(
     `${cmd} bigquery integration_tests_dlp harmful ${topicName} ${subscriptionName} -p ${dataProject}`,
     cwd
   );
-  t.regex(output, /Found \d instance\(s\) of infoType PHONE_NUMBER/);
+  assert.strictEqual(
+    new RegExp(/Found \d instance\(s\) of infoType PHONE_NUMBER/).test(output),
+    true
+  );
 });
 
-test.skip(`should handle a Bigquery table with no sensitive data`, async t => {
+it.skip('should handle a Bigquery table with no sensitive data', async () => {
   const output = await tools.runAsync(
     `${cmd} bigquery integration_tests_dlp harmless ${topicName} ${subscriptionName} -p ${dataProject}`,
     cwd
   );
-  t.regex(output, /No findings/);
+  assert.strictEqual(new RegExp(/No findings/).test(output), true);
 });
 
-test(`should report Bigquery table handling errors`, async t => {
+it('should report Bigquery table handling errors', async () => {
   const output = await tools.runAsync(
     `${cmd} bigquery integration_tests_dlp harmless ${topicName} ${subscriptionName} -t BAD_TYPE -p ${dataProject}`,
     cwd
   );
-  t.regex(output, /Error in inspectBigquery/);
+  assert.strictEqual(new RegExp(/Error in inspectBigquery/).test(output), true);
 });
 
 // CLI options
-test(`should have a minLikelihood option`, async t => {
+it('should have a minLikelihood option', async () => {
   const promiseA = tools.runAsync(
     `${cmd} string "My phone number is (123) 456-7890." -m LIKELY`,
     cwd
@@ -197,14 +215,14 @@ test(`should have a minLikelihood option`, async t => {
   );
 
   const outputA = await promiseA;
-  t.truthy(outputA);
-  t.notRegex(outputA, /PHONE_NUMBER/);
+  assert.ok(outputA);
+  assert.strictEqual(new RegExp(/PHONE_NUMBER/).test(outputA), false);
 
   const outputB = await promiseB;
-  t.regex(outputB, /PHONE_NUMBER/);
+  assert.strictEqual(new RegExp(/PHONE_NUMBER/).test(outputB), true);
 });
 
-test(`should have a maxFindings option`, async t => {
+it('should have a maxFindings option', async () => {
   const promiseA = tools.runAsync(
     `${cmd} string "My email is gary@example.com and my phone number is (223) 456-7890." -f 1`,
     cwd
@@ -215,14 +233,17 @@ test(`should have a maxFindings option`, async t => {
   );
 
   const outputA = await promiseA;
-  t.not(outputA.includes('PHONE_NUMBER'), outputA.includes('EMAIL_ADDRESS')); // Exactly one of these should be included
+  assert.notStrictEqual(
+    outputA.includes('PHONE_NUMBER'),
+    outputA.includes('EMAIL_ADDRESS')
+  ); // Exactly one of these should be included
 
   const outputB = await promiseB;
-  t.regex(outputB, /PHONE_NUMBER/);
-  t.regex(outputB, /EMAIL_ADDRESS/);
+  assert.strictEqual(new RegExp(/PHONE_NUMBER/).test(outputB), true);
+  assert.strictEqual(new RegExp(/EMAIL_ADDRESS/).test(outputB), true);
 });
 
-test(`should have an option to include quotes`, async t => {
+it('should have an option to include quotes', async () => {
   const promiseA = tools.runAsync(
     `${cmd} string "My phone number is (223) 456-7890." -q false`,
     cwd
@@ -233,14 +254,14 @@ test(`should have an option to include quotes`, async t => {
   );
 
   const outputA = await promiseA;
-  t.truthy(outputA);
-  t.notRegex(outputA, /\(223\) 456-7890/);
+  assert.ok(outputA);
+  assert.strictEqual(new RegExp(/\(223\) 456-7890/).test(outputA), false);
 
   const outputB = await promiseB;
-  t.regex(outputB, /\(223\) 456-7890/);
+  assert.strictEqual(new RegExp(/\(223\) 456-7890/).test(outputB), true);
 });
 
-test(`should have an option to filter results by infoType`, async t => {
+it('should have an option to filter results by infoType', async () => {
   const promiseA = tools.runAsync(
     `${cmd} string "My email is gary@example.com and my phone number is (223) 456-7890."`,
     cwd
@@ -251,10 +272,10 @@ test(`should have an option to filter results by infoType`, async t => {
   );
 
   const outputA = await promiseA;
-  t.regex(outputA, /EMAIL_ADDRESS/);
-  t.regex(outputA, /PHONE_NUMBER/);
+  assert.strictEqual(new RegExp(/EMAIL_ADDRESS/).test(outputA), true);
+  assert.strictEqual(new RegExp(/PHONE_NUMBER/).test(outputA), true);
 
   const outputB = await promiseB;
-  t.notRegex(outputB, /EMAIL_ADDRESS/);
-  t.regex(outputB, /PHONE_NUMBER/);
+  assert.strictEqual(new RegExp(/EMAIL_ADDRESS/).test(outputB), false);
+  assert.strictEqual(new RegExp(/PHONE_NUMBER/).test(outputB), true);
 });

--- a/samples/system-test/jobs.test.js
+++ b/samples/system-test/jobs.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/jobs.test.js
+++ b/samples/system-test/jobs.test.js
@@ -15,7 +15,7 @@
 
 'use strict';
 
-const test = require('ava');
+const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
 
 const cmd = `node jobs.js`;
@@ -26,8 +26,6 @@ const testTableProjectId = `bigquery-public-data`;
 const testDatasetId = `san_francisco`;
 const testTableId = `bikeshare_trips`;
 const testColumnName = `zip_code`;
-
-test.before(tools.checkCredentials);
 
 // Helper function for creating test jobs
 const createTestJob = async () => {
@@ -62,35 +60,46 @@ const createTestJob = async () => {
 
 // Create a test job
 let testJobName;
-test.before(async () => {
+before(async () => {
+  tools.checkCredentials();
   testJobName = await createTestJob();
 });
 
 // dlp_list_jobs
-test(`should list jobs`, async t => {
+it('should list jobs', async () => {
   const output = await tools.runAsync(`${cmd} list 'state=DONE'`);
-  t.regex(output, /Job projects\/(\w|-)+\/dlpJobs\/\w-\d+ status: DONE/);
+  assert.strictEqual(
+    new RegExp(/Job projects\/(\w|-)+\/dlpJobs\/\w-\d+ status: DONE/).test(
+      output
+    ),
+    true
+  );
 });
 
-test(`should list jobs of a given type`, async t => {
+it('should list jobs of a given type', async () => {
   const output = await tools.runAsync(
     `${cmd} list 'state=DONE' -t RISK_ANALYSIS_JOB`
   );
-  t.regex(output, /Job projects\/(\w|-)+\/dlpJobs\/r-\d+ status: DONE/);
+  assert.strictEqual(
+    new RegExp(/Job projects\/(\w|-)+\/dlpJobs\/r-\d+ status: DONE/).test(
+      output
+    ),
+    true
+  );
 });
 
-test(`should handle job listing errors`, async t => {
+it('should handle job listing errors', async () => {
   const output = await tools.runAsync(`${cmd} list 'state=NOPE'`);
-  t.regex(output, /Error in listJobs/);
+  assert.strictEqual(new RegExp(/Error in listJobs/).test(output), true);
 });
 
 // dlp_delete_job
-test(`should delete job`, async t => {
+it('should delete job', async () => {
   const output = await tools.runAsync(`${cmd} delete ${testJobName}`);
-  t.is(output, `Successfully deleted job ${testJobName}.`);
+  assert.strictEqual(output, `Successfully deleted job ${testJobName}.`);
 });
 
-test(`should handle job deletion errors`, async t => {
+it('should handle job deletion errors', async () => {
   const output = await tools.runAsync(`${cmd} delete ${badJobName}`);
-  t.regex(output, /Error in deleteJob/);
+  assert.strictEqual(new RegExp(/Error in deleteJob/).test(output), true);
 });

--- a/samples/system-test/metadata.test.js
+++ b/samples/system-test/metadata.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/metadata.test.js
+++ b/samples/system-test/metadata.test.js
@@ -16,23 +16,29 @@
 'use strict';
 
 const path = require('path');
-const test = require('ava');
+const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
 
 const cmd = 'node metadata.js';
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, '..');
 
-test.before(tools.checkCredentials);
+before(tools.checkCredentials);
 
-test(`should list info types`, async t => {
+it('should list info types', async () => {
   const output = await tools.runAsync(`${cmd} infoTypes`, cwd);
-  t.regex(output, /US_DRIVERS_LICENSE_NUMBER/);
+  assert.strictEqual(
+    new RegExp(/US_DRIVERS_LICENSE_NUMBER/).test(output),
+    true
+  );
 });
 
-test(`should filter listed info types`, async t => {
+it('should filter listed info types', async () => {
   const output = await tools.runAsync(
     `${cmd} infoTypes "supported_by=RISK_ANALYSIS"`,
     cwd
   );
-  t.notRegex(output, /US_DRIVERS_LICENSE_NUMBER/);
+  assert.strictEqual(
+    new RegExp(/US_DRIVERS_LICENSE_NUMBER/).test(output),
+    false
+  );
 });

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/quickstart.test.js
+++ b/samples/system-test/quickstart.test.js
@@ -16,15 +16,15 @@
 'use strict';
 
 const path = require('path');
-const test = require('ava');
+const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
 
 const cmd = 'node quickstart.js';
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, '..');
 
-test.before(tools.checkCredentials);
+before(tools.checkCredentials);
 
-test(`should run`, async t => {
+it('should run', async () => {
   const output = await tools.runAsync(cmd, cwd);
-  t.regex(output, /Info type: PERSON_NAME/);
+  assert.strictEqual(new RegExp(/Info type: PERSON_NAME/).test(output), true);
 });

--- a/samples/system-test/redact.test.js
+++ b/samples/system-test/redact.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/redact.test.js
+++ b/samples/system-test/redact.test.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const path = require('path');
-const test = require('ava');
+const assert = require('assert');
 const fs = require('fs');
 const tools = require('@google-cloud/nodejs-repo-tools');
 const PNG = require('pngjs').PNG;
@@ -28,7 +28,7 @@ const cwd = path.join(__dirname, `..`);
 const testImage = 'resources/test.png';
 const testResourcePath = 'system-test/resources';
 
-test.before(tools.checkCredentials);
+before(tools.checkCredentials);
 
 function readImage(filePath) {
   return new Promise((resolve, reject) => {
@@ -57,75 +57,93 @@ async function getImageDiffPercentage(image1Path, image2Path) {
 }
 
 // redact_text
-test(`should redact a single sensitive data type from a string`, async t => {
+it('should redact a single sensitive data type from a string', async () => {
   const output = await tools.runAsync(
     `${cmd} string "My email is jenny@example.com" -t EMAIL_ADDRESS`,
     cwd
   );
-  t.regex(output, /My email is \[EMAIL_ADDRESS\]/);
+  assert.strictEqual(
+    new RegExp(/My email is \[EMAIL_ADDRESS\]/).test(output),
+    true
+  );
 });
 
-test(`should redact multiple sensitive data types from a string`, async t => {
+it('should redact multiple sensitive data types from a string', async () => {
   const output = await tools.runAsync(
     `${cmd} string "I am 29 years old and my email is jenny@example.com" -t EMAIL_ADDRESS AGE`,
     cwd
   );
-  t.regex(output, /I am \[AGE\] and my email is \[EMAIL_ADDRESS\]/);
+  assert.strictEqual(
+    new RegExp(/I am \[AGE\] and my email is \[EMAIL_ADDRESS\]/).test(output),
+    true
+  );
 });
 
-test(`should handle string with no sensitive data`, async t => {
+it('should handle string with no sensitive data', async () => {
   const output = await tools.runAsync(
     `${cmd} string "No sensitive data to redact here" -t EMAIL_ADDRESS AGE`,
     cwd
   );
-  t.regex(output, /No sensitive data to redact here/);
+  assert.strictEqual(
+    new RegExp(/No sensitive data to redact here/).test(output),
+    true
+  );
 });
 
 // redact_image
-test(`should redact a single sensitive data type from an image`, async t => {
+it('should redact a single sensitive data type from an image', async () => {
   const testName = `redact-single-type`;
   const output = await tools.runAsync(
     `${cmd} image ${testImage} ${testName}.actual.png -t PHONE_NUMBER`,
     cwd
   );
 
-  t.regex(output, /Saved image redaction results to path/);
+  assert.strictEqual(
+    new RegExp(/Saved image redaction results to path/).test(output),
+    true
+  );
 
   const difference = await getImageDiffPercentage(
     `${testName}.actual.png`,
     `${testResourcePath}/${testName}.expected.png`
   );
-  t.true(difference < 0.03);
+  assert.strictEqual(difference < 0.03, true);
 });
 
-test(`should redact multiple sensitive data types from an image`, async t => {
+it('should redact multiple sensitive data types from an image', async () => {
   const testName = `redact-multiple-types`;
   const output = await tools.runAsync(
     `${cmd} image ${testImage} ${testName}.actual.png -t PHONE_NUMBER EMAIL_ADDRESS`,
     cwd
   );
 
-  t.regex(output, /Saved image redaction results to path/);
+  assert.strictEqual(
+    new RegExp(/Saved image redaction results to path/).test(output),
+    true
+  );
 
   const difference = await getImageDiffPercentage(
     `${testName}.actual.png`,
     `${testResourcePath}/${testName}.expected.png`
   );
-  t.true(difference < 0.03);
+  assert.strictEqual(difference < 0.03, true);
 });
 
-test(`should report info type errors`, async t => {
+it('should report info type errors', async () => {
   const output = await tools.runAsync(
     `${cmd} string "My email is jenny@example.com" -t NONEXISTENT`,
     cwd
   );
-  t.regex(output, /Error in deidentifyContent/);
+  assert.strictEqual(
+    new RegExp(/Error in deidentifyContent/).test(output),
+    true
+  );
 });
 
-test(`should report image redaction handling errors`, async t => {
+it('should report image redaction handling errors', async () => {
   const output = await tools.runAsync(
     `${cmd} image ${testImage} output.png -t BAD_TYPE`,
     cwd
   );
-  t.regex(output, /Error in redactImage/);
+  assert.strictEqual(new RegExp(/Error in redactImage/).test(output), true);
 });

--- a/samples/system-test/risk.test.js
+++ b/samples/system-test/risk.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/risk.test.js
+++ b/samples/system-test/risk.test.js
@@ -16,14 +16,14 @@
 'use strict';
 
 const path = require('path');
-const test = require('ava');
+const assert = require('assert');
 const uuid = require('uuid');
-const PubSub = require(`@google-cloud/pubsub`);
+const PubSub = require('@google-cloud/pubsub');
 const pubsub = new PubSub();
 const tools = require('@google-cloud/nodejs-repo-tools');
 
 const cmd = 'node risk.js';
-const cwd = path.join(__dirname, `..`);
+const cwd = path.join(__dirname, '..');
 
 const dataset = 'integration_tests_dlp';
 const uniqueField = 'Name';
@@ -32,13 +32,12 @@ const numericField = 'Age';
 const stringBooleanField = 'Gender';
 const testProjectId = process.env.GCLOUD_PROJECT;
 
-test.before(tools.checkCredentials);
-
 // Create new custom topic/subscription
 let topic, subscription;
 const topicName = `dlp-risk-topic-${uuid.v4()}`;
 const subscriptionName = `dlp-risk-subscription-${uuid.v4()}`;
-test.before(async () => {
+before(async () => {
+  tools.checkCredentials();
   await pubsub
     .createTopic(topicName)
     .then(response => {
@@ -51,145 +50,200 @@ test.before(async () => {
 });
 
 // Delete custom topic/subscription
-test.after.always(async () => {
-  await subscription.delete().then(() => topic.delete());
-});
+after(async () => await subscription.delete().then(() => topic.delete()));
 
 // numericalRiskAnalysis
-test(`should perform numerical risk analysis`, async t => {
+it('should perform numerical risk analysis', async () => {
   const output = await tools.runAsync(
     `${cmd} numerical ${dataset} harmful ${numericField} ${topicName} ${subscriptionName} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Value at 0% quantile: \d{2}/);
-  t.regex(output, /Value at \d{2}% quantile: \d{2}/);
+  assert.strictEqual(
+    new RegExp(/Value at 0% quantile: \d{2}/).test(output),
+    true
+  );
+  assert.strictEqual(
+    new RegExp(/Value at \d{2}% quantile: \d{2}/).test(output),
+    true
+  );
 });
 
-test(`should handle numerical risk analysis errors`, async t => {
+it('should handle numerical risk analysis errors', async () => {
   const output = await tools.runAsync(
     `${cmd} numerical ${dataset} nonexistent ${numericField} ${topicName} ${subscriptionName} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Error in numericalRiskAnalysis/);
+  assert.strictEqual(
+    new RegExp(/Error in numericalRiskAnalysis/).test(output),
+    true
+  );
 });
 
 // categoricalRiskAnalysis
-test(`should perform categorical risk analysis on a string field`, async t => {
+it('should perform categorical risk analysis on a string field', async () => {
   const output = await tools.runAsync(
     `${cmd} categorical ${dataset} harmful ${uniqueField} ${topicName} ${subscriptionName} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Most common value occurs \d time\(s\)/);
+  assert.strictEqual(
+    new RegExp(/Most common value occurs \d time\(s\)/).test(output),
+    true
+  );
 });
 
-test(`should perform categorical risk analysis on a number field`, async t => {
+it('should perform categorical risk analysis on a number field', async () => {
   const output = await tools.runAsync(
     `${cmd} categorical ${dataset} harmful ${numericField} ${topicName} ${subscriptionName} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Most common value occurs \d time\(s\)/);
+  assert.strictEqual(
+    new RegExp(/Most common value occurs \d time\(s\)/).test(output),
+    true
+  );
 });
 
-test(`should handle categorical risk analysis errors`, async t => {
+it('should handle categorical risk analysis errors', async () => {
   const output = await tools.runAsync(
     `${cmd} categorical ${dataset} nonexistent ${uniqueField} ${topicName} ${subscriptionName} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Error in categoricalRiskAnalysis/);
+  assert.strictEqual(
+    new RegExp(/Error in categoricalRiskAnalysis/).test(output),
+    true
+  );
 });
 
 // kAnonymityAnalysis
-test(`should perform k-anonymity analysis on a single field`, async t => {
+it('should perform k-anonymity analysis on a single field', async () => {
   const output = await tools.runAsync(
     `${cmd} kAnonymity ${dataset} harmful ${topicName} ${subscriptionName} ${numericField} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Quasi-ID values: \{\d{2}\}/);
-  t.regex(output, /Class size: \d/);
+  assert.strictEqual(
+    new RegExp(/Quasi-ID values: \{\d{2}\}/).test(output),
+    true
+  );
+  assert.strictEqual(new RegExp(/Class size: \d/).test(output), true);
 });
 
-test(`should perform k-anonymity analysis on multiple fields`, async t => {
+it('should perform k-anonymity analysis on multiple fields', async () => {
   const output = await tools.runAsync(
     `${cmd} kAnonymity ${dataset} harmful ${topicName} ${subscriptionName} ${numericField} ${repeatedField} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Quasi-ID values: \{\d{2}, \d{4} \d{4} \d{4} \d{4}\}/);
-  t.regex(output, /Class size: \d/);
+  assert.strictEqual(
+    new RegExp(/Quasi-ID values: \{\d{2}, \d{4} \d{4} \d{4} \d{4}\}/).test(
+      output
+    ),
+    true
+  );
+  assert.strictEqual(new RegExp(/Class size: \d/).test(output), true);
 });
 
-test(`should handle k-anonymity analysis errors`, async t => {
+it('should handle k-anonymity analysis errors', async () => {
   const output = await tools.runAsync(
     `${cmd} kAnonymity ${dataset} nonexistent ${topicName} ${subscriptionName} ${numericField} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Error in kAnonymityAnalysis/);
+  assert.strictEqual(
+    new RegExp(/Error in kAnonymityAnalysis/).test(output),
+    true
+  );
 });
 
 // kMapAnalysis
-test(`should perform k-map analysis on a single field`, async t => {
+it('should perform k-map analysis on a single field', async () => {
   const output = await tools.runAsync(
     `${cmd} kMap ${dataset} harmful ${topicName} ${subscriptionName} ${numericField} -t AGE -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Anonymity range: \[\d+, \d+\]/);
-  t.regex(output, /Size: \d/);
-  t.regex(output, /Values: \d{2}/);
+  assert.strictEqual(
+    new RegExp(/Anonymity range: \[\d+, \d+\]/).test(output),
+    true
+  );
+  assert.strictEqual(new RegExp(/Size: \d/).test(output), true);
+  assert.strictEqual(new RegExp(/Values: \d{2}/).test(output), true);
 });
 
-test(`should perform k-map analysis on multiple fields`, async t => {
+it('should perform k-map analysis on multiple fields', async () => {
   const output = await tools.runAsync(
     `${cmd} kMap ${dataset} harmful ${topicName} ${subscriptionName} ${numericField} ${stringBooleanField} -t AGE GENDER -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Anonymity range: \[\d+, \d+\]/);
-  t.regex(output, /Size: \d/);
-  t.regex(output, /Values: \d{2} Female/);
+  assert.strictEqual(
+    new RegExp(/Anonymity range: \[\d+, \d+\]/).test(output),
+    true
+  );
+  assert.strictEqual(new RegExp(/Size: \d/).test(output), true);
+  assert.strictEqual(new RegExp(/Values: \d{2} Female/).test(output), true);
 });
 
-test(`should handle k-map analysis errors`, async t => {
+it('should handle k-map analysis errors', async () => {
   const output = await tools.runAsync(
     `${cmd} kMap ${dataset} nonexistent ${topicName} ${subscriptionName} ${numericField} -t AGE -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Error in kMapEstimationAnalysis/);
+  assert.strictEqual(
+    new RegExp(/Error in kMapEstimationAnalysis/).test(output),
+    true
+  );
 });
 
-test(`should check that numbers of quasi-ids and info types are equal`, async t => {
+it('should check that numbers of quasi-ids and info types are equal', async () => {
   const errors = await tools.runAsyncWithIO(
     `${cmd} kMap ${dataset} nonexistent ${topicName} ${subscriptionName} ${numericField} -t AGE GENDER -p ${testProjectId}`,
     cwd
   );
-  t.regex(
-    errors.stderr,
-    /Number of infoTypes and number of quasi-identifiers must be equal!/
+  assert.strictEqual(
+    new RegExp(
+      /Number of infoTypes and number of quasi-identifiers must be equal!/
+    ).test(errors.stderr),
+    true
   );
 });
 
 // lDiversityAnalysis
-test(`should perform l-diversity analysis on a single field`, async t => {
+it('should perform l-diversity analysis on a single field', async () => {
   const output = await tools.runAsync(
     `${cmd} lDiversity ${dataset} harmful ${uniqueField} ${topicName} ${subscriptionName} ${numericField} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Quasi-ID values: \{\d{2}\}/);
-  t.regex(output, /Class size: \d/);
-  t.regex(output, /Sensitive value James occurs \d time\(s\)/);
+  assert.strictEqual(
+    new RegExp(/Quasi-ID values: \{\d{2}\}/).test(output),
+    true
+  );
+  assert.strictEqual(new RegExp(/Class size: \d/).test(output), true);
+  assert.strictEqual(
+    new RegExp(/Sensitive value James occurs \d time\(s\)/).test(output),
+    true
+  );
 });
 
-test(`should perform l-diversity analysis on multiple fields`, async t => {
+it('should perform l-diversity analysis on multiple fields', async () => {
   const output = await tools.runAsync(
     `${cmd} lDiversity ${dataset} harmful ${uniqueField} ${topicName} ${subscriptionName} ${numericField} ${repeatedField} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Quasi-ID values: \{\d{2}, \d{4} \d{4} \d{4} \d{4}\}/);
-  t.regex(output, /Class size: \d/);
-  t.regex(output, /Sensitive value James occurs \d time\(s\)/);
+  assert.strictEqual(
+    new RegExp(/Quasi-ID values: \{\d{2}, \d{4} \d{4} \d{4} \d{4}\}/).test(
+      output
+    ),
+    true
+  );
+  assert.strictEqual(new RegExp(/Class size: \d/).test(output), true);
+  assert.strictEqual(
+    new RegExp(/Sensitive value James occurs \d time\(s\)/).test(output),
+    true
+  );
 });
 
-test(`should handle l-diversity analysis errors`, async t => {
+it('should handle l-diversity analysis errors', async () => {
   const output = await tools.runAsync(
     `${cmd} lDiversity ${dataset} nonexistent ${topicName} ${subscriptionName} ${numericField} -p ${testProjectId}`,
     cwd
   );
-  t.regex(output, /Error in lDiversityAnalysis/);
+  assert.strictEqual(
+    new RegExp(/Error in lDiversityAnalysis/).test(output),
+    true
+  );
 });

--- a/samples/system-test/templates.test.js
+++ b/samples/system-test/templates.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/templates.test.js
+++ b/samples/system-test/templates.test.js
@@ -15,15 +15,17 @@
 
 'use strict';
 
-const test = require(`ava`);
+const path = require('path');
+const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
-const uuid = require(`uuid`);
+const uuid = require('uuid');
 
-const cmd = `node templates.js`;
+const cmd = 'node templates.js';
+const cwd = path.join(__dirname, '..');
 const templateName = '';
 
-const INFO_TYPE = `PERSON_NAME`;
-const MIN_LIKELIHOOD = `VERY_LIKELY`;
+const INFO_TYPE = 'PERSON_NAME';
+const MIN_LIKELIHOOD = 'VERY_LIKELY';
 const MAX_FINDINGS = 5;
 const INCLUDE_QUOTE = false;
 const DISPLAY_NAME = `My Template ${uuid.v4()}`;
@@ -34,43 +36,71 @@ const fullTemplateName = `projects/${
 }/inspectTemplates/${TEMPLATE_NAME}`;
 
 // create_inspect_template
-test.serial(`should create template`, async t => {
+it('should create template', async () => {
   const output = await tools.runAsync(
-    `${cmd} create -m ${MIN_LIKELIHOOD} -t ${INFO_TYPE} -f ${MAX_FINDINGS} -q ${INCLUDE_QUOTE} -d "${DISPLAY_NAME}" -i "${TEMPLATE_NAME}"`
+    `${cmd} create -m ${MIN_LIKELIHOOD} -t ${INFO_TYPE} -f ${MAX_FINDINGS} -q ${INCLUDE_QUOTE} -d "${DISPLAY_NAME}" -i "${TEMPLATE_NAME}"`,
+    cwd
   );
-  t.true(output.includes(`Successfully created template ${fullTemplateName}`));
+  assert.strictEqual(
+    output.includes(`Successfully created template ${fullTemplateName}`),
+    true
+  );
 });
 
-test(`should handle template creation errors`, async t => {
-  const output = await tools.runAsync(`${cmd} create -i invalid_template#id`);
-  t.regex(output, /Error in createInspectTemplate/);
+it('should handle template creation errors', async () => {
+  const output = await tools.runAsync(
+    `${cmd} create -i invalid_template#id`,
+    cwd
+  );
+  assert.strictEqual(
+    new RegExp(/Error in createInspectTemplate/).test(output),
+    true
+  );
 });
 
 // list_inspect_templates
-test.serial(`should list templates`, async t => {
-  const output = await tools.runAsync(`${cmd} list`);
-  t.true(output.includes(`Template ${templateName}`));
-  t.regex(output, /Created: \d{1,2}\/\d{1,2}\/\d{4}/);
-  t.regex(output, /Updated: \d{1,2}\/\d{1,2}\/\d{4}/);
+it('should list templates', async () => {
+  const output = await tools.runAsync(`${cmd} list`, cwd);
+  assert.strictEqual(output.includes(`Template ${templateName}`), true);
+  assert.strictEqual(
+    new RegExp(/Created: \d{1,2}\/\d{1,2}\/\d{4}/).test(output),
+    true
+  );
+  assert.strictEqual(
+    new RegExp(/Updated: \d{1,2}\/\d{1,2}\/\d{4}/).test(output),
+    true
+  );
 });
 
-test.serial(`should pass creation settings to template`, async t => {
-  const output = await tools.runAsync(`${cmd} list`);
-  t.true(output.includes(`Template ${fullTemplateName}`));
-  t.true(output.includes(`Display name: ${DISPLAY_NAME}`));
-  t.true(output.includes(`InfoTypes: ${INFO_TYPE}`));
-  t.true(output.includes(`Minimum likelihood: ${MIN_LIKELIHOOD}`));
-  t.true(output.includes(`Include quotes: ${INCLUDE_QUOTE}`));
-  t.true(output.includes(`Max findings per request: ${MAX_FINDINGS}`));
+it('should pass creation settings to template', async () => {
+  const output = await tools.runAsync(`${cmd} list`, cwd);
+  assert.strictEqual(output.includes(`Template ${fullTemplateName}`), true);
+  assert.strictEqual(output.includes(`Display name: ${DISPLAY_NAME}`), true);
+  assert.strictEqual(output.includes(`InfoTypes: ${INFO_TYPE}`), true);
+  assert.strictEqual(
+    output.includes(`Minimum likelihood: ${MIN_LIKELIHOOD}`),
+    true
+  );
+  assert.strictEqual(output.includes(`Include quotes: ${INCLUDE_QUOTE}`), true);
+  assert.strictEqual(
+    output.includes(`Max findings per request: ${MAX_FINDINGS}`),
+    true
+  );
 });
 
 // delete_inspect_template
-test.serial(`should delete template`, async t => {
-  const output = await tools.runAsync(`${cmd} delete ${fullTemplateName}`);
-  t.true(output.includes(`Successfully deleted template ${fullTemplateName}.`));
+it('should delete template', async () => {
+  const output = await tools.runAsync(`${cmd} delete ${fullTemplateName}`, cwd);
+  assert.strictEqual(
+    output.includes(`Successfully deleted template ${fullTemplateName}.`),
+    true
+  );
 });
 
-test(`should handle template deletion errors`, async t => {
-  const output = await tools.runAsync(`${cmd} delete BAD_TEMPLATE`);
-  t.regex(output, /Error in deleteInspectTemplate/);
+it('should handle template deletion errors', async () => {
+  const output = await tools.runAsync(`${cmd} delete BAD_TEMPLATE`, cwd);
+  assert.strictEqual(
+    new RegExp(/Error in deleteInspectTemplate/).test(output),
+    true
+  );
 });

--- a/samples/system-test/triggers.test.js
+++ b/samples/system-test/triggers.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017, Google, Inc.
+ * Copyright 2018, Google, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/samples/system-test/triggers.test.js
+++ b/samples/system-test/triggers.test.js
@@ -14,55 +14,76 @@
  */
 
 'use strict';
-
-const test = require(`ava`);
+const path = require('path');
+const assert = require('assert');
 const tools = require('@google-cloud/nodejs-repo-tools');
-const uuid = require(`uuid`);
+const uuid = require('uuid');
 
 const projectId = process.env.GCLOUD_PROJECT;
-const cmd = `node triggers.js`;
+const cmd = 'node triggers.js';
+const cwd = path.join(__dirname, '..');
 const triggerName = `my-trigger-${uuid.v4()}`;
 const fullTriggerName = `projects/${projectId}/jobTriggers/${triggerName}`;
 const triggerDisplayName = `My Trigger Display Name: ${uuid.v4()}`;
 const triggerDescription = `My Trigger Description: ${uuid.v4()}`;
 
-const infoType = `US_CENSUS_NAME`;
-const minLikelihood = `VERY_LIKELY`;
+const infoType = 'US_CENSUS_NAME';
+const minLikelihood = 'VERY_LIKELY';
 const maxFindings = 5;
 const bucketName = process.env.BUCKET_NAME;
 
-test.serial(`should create a trigger`, async t => {
+it('should create a trigger', async () => {
   const output = await tools.runAsync(
     `${cmd} create ${bucketName} 1 -n ${triggerName} --autoPopulateTimespan \
-    -m ${minLikelihood} -t ${infoType} -f ${maxFindings} -d "${triggerDisplayName}" -s "${triggerDescription}"`
+    -m ${minLikelihood} -t ${infoType} -f ${maxFindings} -d "${triggerDisplayName}" -s "${triggerDescription}"`,
+    cwd
   );
-  t.true(output.includes(`Successfully created trigger ${fullTriggerName}`));
+  assert.strictEqual(
+    output.includes(`Successfully created trigger ${fullTriggerName}`),
+    true
+  );
 });
 
-test.serial(`should list triggers`, async t => {
-  const output = await tools.runAsync(`${cmd} list`);
-  t.true(output.includes(`Trigger ${fullTriggerName}`));
-  t.true(output.includes(`Display Name: ${triggerDisplayName}`));
-  t.true(output.includes(`Description: ${triggerDescription}`));
-  t.regex(output, /Created: \d{1,2}\/\d{1,2}\/\d{4}/);
-  t.regex(output, /Updated: \d{1,2}\/\d{1,2}\/\d{4}/);
-  t.regex(output, /Status: HEALTHY/);
-  t.regex(output, /Error count: 0/);
+it('should list triggers', async () => {
+  const output = await tools.runAsync(`${cmd} list`, cwd);
+  assert.strictEqual(output.includes(`Trigger ${fullTriggerName}`), true);
+  assert.strictEqual(
+    output.includes(`Display Name: ${triggerDisplayName}`),
+    true
+  );
+  assert.strictEqual(
+    output.includes(`Description: ${triggerDescription}`),
+    true
+  );
+  assert.strictEqual(
+    new RegExp(/Created: \d{1,2}\/\d{1,2}\/\d{4}/).test(output),
+    true
+  );
+  assert.strictEqual(
+    new RegExp(/Updated: \d{1,2}\/\d{1,2}\/\d{4}/).test(output),
+    true
+  );
+  assert.strictEqual(new RegExp(/Status: HEALTHY/).test(output), true);
+  assert.strictEqual(new RegExp(/Error count: 0/).test(output), true);
 });
 
-test.serial(`should delete a trigger`, async t => {
-  const output = await tools.runAsync(`${cmd} delete ${fullTriggerName}`);
-  t.true(output.includes(`Successfully deleted trigger ${fullTriggerName}.`));
+it('should delete a trigger', async () => {
+  const output = await tools.runAsync(`${cmd} delete ${fullTriggerName}`, cwd);
+  assert.strictEqual(
+    output.includes(`Successfully deleted trigger ${fullTriggerName}.`),
+    true
+  );
 });
 
-test(`should handle trigger creation errors`, async t => {
+it('should handle trigger creation errors', async () => {
   const output = await tools.runAsync(
-    `${cmd} create ${bucketName} 1 -n "@@@@@" -m ${minLikelihood} -t ${infoType} -f ${maxFindings}`
+    `${cmd} create ${bucketName} 1 -n "@@@@@" -m ${minLikelihood} -t ${infoType} -f ${maxFindings}`,
+    cwd
   );
-  t.regex(output, /Error in createTrigger/);
+  assert.strictEqual(new RegExp(/Error in createTrigger/).test(output), true);
 });
 
-test(`should handle trigger deletion errors`, async t => {
-  const output = await tools.runAsync(`${cmd} delete bad-trigger-path`);
-  t.regex(output, /Error in deleteTrigger/);
+it('should handle trigger deletion errors', async () => {
+  const output = await tools.runAsync(`${cmd} delete bad-trigger-path`, cwd);
+  assert.strictEqual(new RegExp(/Error in deleteTrigger/).test(output), true);
 });


### PR DESCRIPTION
Fixes convert all sample tests from ava to mocha [#2865](https://github.com/googleapis/google-cloud-node/issues/2865) (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
