### PR TITLE
chore: use spawn for list jobs sample test

### DIFF
--- a/samples/system-test/jobs.test.js
+++ b/samples/system-test/jobs.test.js
@@ -77,7 +77,7 @@ it('should list jobs', async () => {
 });
 
 it('should list jobs of a given type', async () => {
-  const output = await tools.runAsync(
+  const {output} = await tools.spawnAsyncWithIO(
     `${cmd} list 'state=DONE' -t RISK_ANALYSIS_JOB`
   );
   assert.strictEqual(


### PR DESCRIPTION
Starting see this error in https://github.com/googleapis/nodejs-dlp/pull/235

```
  1) should list jobs of a given type:
     Error: stdout maxBuffer exceeded
      at Socket.onChildStdout (child_process.js:334:14)
      at addChunk (_stream_readable.js:263:12)
      at readableAddChunk (_stream_readable.js:246:13)
      at Socket.Readable.push (_stream_readable.js:208:10)
      at Pipe.onread (net.js:601:20)
```

I think switching from `exec` to `spawn` should fix it.