### PR TITLE
fix(test): increase minLikelihood option threshold to VERY_LIKELY

### DIFF
--- a/samples/system-test/inspect.test.js
+++ b/samples/system-test/inspect.test.js
@@ -188,7 +188,8 @@ describe('inspect', () => {
   });
 
   // CLI options
-  it.only('should have a minLikelihood option', async () => {
+  // This test is potentially flaky, possibly because of model changes.
+  it('should have a minLikelihood option', async () => {
     const outputA = await exec(
       `${cmd} string "My phone number is (123) 456-7890." -m VERY_LIKELY`
     );

--- a/samples/system-test/inspect.test.js
+++ b/samples/system-test/inspect.test.js
@@ -188,9 +188,9 @@ describe('inspect', () => {
   });
 
   // CLI options
-  it('should have a minLikelihood option', async () => {
+  it.only('should have a minLikelihood option', async () => {
     const outputA = await exec(
-      `${cmd} string "My phone number is (123) 456-7890." -m LIKELY`
+      `${cmd} string "My phone number is (123) 456-7890." -m VERY_LIKELY`
     );
     const outputB = await exec(
       `${cmd} string "My phone number is (123) 456-7890." -m UNLIKELY`


### PR DESCRIPTION
This one is annoying. I've personally fixed at least 3 instances of samples test failure due to some model changes in the DLP backend. We need a better way to test this.