### PR TITLE
Fix samples readme reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npm install @google-cloud/dlp
 
 ## Samples
 
-Samples are in the [`samples/`](https://github.com/googleapis/nodejs-dlp/tree/master/samples) directory. The samples' `README.md`
+Samples are in the [`samples/`](https://github.com/googleapis/nodejs-dlp/tree/master/samples) directory. The samples [README.md](samples/README.md)
 has instructions for running the samples.
 
 | Sample                      | Source Code                       | Try it |


### PR DESCRIPTION
While `samples` is plural, it's actually the "samples directory" directory which would be singular (and thus if you're going to use an apostrophe, it'd be `samples's`. But in normal speech, we talk about files in a directory just as such... It's simpler to omit the possessive.

Beyond that, markdown can link to files, which makes things better.

Note: if you actually mean "each sample's readme" then it would be best to use the word *each*, as otherwise the most likely interpretation is the one I'm making, or at the very least it's definitely ambiguous.