### PR TITLE
test: upstream breaking change broke tests

### DIFF
--- a/samples/risk.js
+++ b/samples/risk.js
@@ -97,10 +97,14 @@ async function numericalRiskAnalysis(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    const jobNameSuffix = jobName.split('/').pop();
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {
-        if (message.attributes && message.attributes.DlpJobName === jobName) {
+        if (
+          message.attributes &&
+          message.attributes.DlpJobName.includes(jobNameSuffix)
+        ) {
           message.ack();
           subscription.removeListener('message', messageHandler);
           subscription.removeListener('error', errorHandler);
@@ -232,10 +236,14 @@ async function categoricalRiskAnalysis(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    const jobNameSuffix = jobName.split('/').pop();
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {
-        if (message.attributes && message.attributes.DlpJobName === jobName) {
+        if (
+          message.attributes &&
+          message.attributes.DlpJobName.includes(jobNameSuffix)
+        ) {
           message.ack();
           subscription.removeListener('message', messageHandler);
           subscription.removeListener('error', errorHandler);
@@ -366,10 +374,14 @@ async function kAnonymityAnalysis(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    const jobNameSuffix = jobName.split('/').pop();
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {
-        if (message.attributes && message.attributes.DlpJobName === jobName) {
+        if (
+          message.attributes &&
+          message.attributes.DlpJobName.includes(jobNameSuffix)
+        ) {
           message.ack();
           subscription.removeListener('message', messageHandler);
           subscription.removeListener('error', errorHandler);
@@ -501,10 +513,14 @@ async function lDiversityAnalysis(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    const jobNameSuffix = jobName.split('/').pop();
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {
-        if (message.attributes && message.attributes.DlpJobName === jobName) {
+        if (
+          message.attributes &&
+          message.attributes.DlpJobName.includes(jobNameSuffix)
+        ) {
           message.ack();
           subscription.removeListener('message', messageHandler);
           subscription.removeListener('error', errorHandler);
@@ -643,10 +659,14 @@ async function kMapEstimationAnalysis(
     const subscription = await topicResponse.subscription(subscriptionId);
     const [jobsResponse] = await dlp.createDlpJob(request);
     const jobName = jobsResponse.name;
+    const jobNameSuffix = jobName.split('/').pop();
     // Watch the Pub/Sub topic until the DLP job finishes
     await new Promise((resolve, reject) => {
       const messageHandler = message => {
-        if (message.attributes && message.attributes.DlpJobName === jobName) {
+        if (
+          message.attributes &&
+          message.attributes.DlpJobName.includes(jobNameSuffix)
+        ) {
           message.ack();
           subscription.removeListener('message', messageHandler);
           subscription.removeListener('error', errorHandler);

--- a/samples/system-test/risk.test.js
+++ b/samples/system-test/risk.test.js
@@ -46,12 +46,34 @@ const pubsub = new PubSub();
 describe('risk', () => {
   // Create new custom topic/subscription
   let topic, subscription;
-  const topicName = `dlp-risk-topic-${uuid.v4()}`;
-  const subscriptionName = `dlp-risk-subscription-${uuid.v4()}`;
+  const topicName = `dlp-risk-topic-${uuid.v4()}-${Date.now()}`;
+  const subscriptionName = `dlp-risk-subscription-${uuid.v4()}-${Date.now()}`;
   before(async () => {
     [topic] = await pubsub.createTopic(topicName);
     [subscription] = await topic.createSubscription(subscriptionName);
+    await deleteOldTopics();
   });
+
+  async function deleteOldTopics() {
+    const [topics] = await pubsub.getTopics();
+    const now = Date.now();
+    const TEN_HOURS_MS = 1000 * 60 * 60 * 10;
+    for (const topic of topics) {
+      const created = Number(topic.name.split('-').pop());
+      if (
+        topic.name.includes('dlp-risk-topic') &&
+        now - created > TEN_HOURS_MS
+      ) {
+        const [subscriptions] = await topic.getSubscriptions();
+        for (const subscription of subscriptions) {
+          console.info(`deleting ${subscription.name}`);
+          await subscription.delete();
+        }
+        console.info(`deleting ${topic.name}`);
+        await topic.delete();
+      }
+    }
+  }
 
   // Delete custom topic/subscription
   after(async () => {

--- a/samples/system-test/risk.test.js
+++ b/samples/system-test/risk.test.js
@@ -86,7 +86,6 @@ describe('risk', () => {
     const output = execSync(
       `${cmd} numerical ${dataset} harmful ${numericField} ${topicName} ${subscriptionName} -p ${testProjectId}`
     );
-    console.info(output);
     assert.match(output, /Value at 0% quantile:/);
     assert.match(output, /Value at \d+% quantile:/);
   });


### PR DESCRIPTION
1. there was a breaking change upstream that caused `message.attributes.DlpJobName` to be populated as a full resource path,  it looks like prior to this it was a shortened resource name.
2. we had 1000s of stale jobs, which was making tests run slow in general (I have added cleanup for this).