### PR TITLE
docs: add pattern reognition for running samples

### DIFF
--- a/samples/inspectBigQuery.js
+++ b/samples/inspectBigQuery.js
@@ -64,7 +64,7 @@ function main(
 
   // The customInfoTypes of information to match
   // const customInfoTypes = [{ infoType: { name: 'DICT_TYPE' }, dictionary: { wordList: { words: ['foo', 'bar', 'baz']}}},
-  //   { infoType: { name: 'REGEX_TYPE' }, regex: '\\(\\d{3}\\) \\d{3}-\\d{4}'}];
+  //   { infoType: { name: 'REGEX_TYPE' }, regex: {pattern: '\\(\\d{3}\\) \\d{3}-\\d{4}'}}];
 
   // The name of the Pub/Sub topic to notify once the job completes
   // TODO(developer): create a Pub/Sub topic to use for this

--- a/samples/inspectDatastore.js
+++ b/samples/inspectDatastore.js
@@ -67,7 +67,7 @@ function main(
 
   // The customInfoTypes of information to match
   // const customInfoTypes = [{ infoType: { name: 'DICT_TYPE' }, dictionary: { wordList: { words: ['foo', 'bar', 'baz']}}},
-  //   { infoType: { name: 'REGEX_TYPE' }, regex: '\\(\\d{3}\\) \\d{3}-\\d{4}'}];
+  //   { infoType: { name: 'REGEX_TYPE' }, regex: {pattern: '\\(\\d{3}\\) \\d{3}-\\d{4}'}}];
 
   // The name of the Pub/Sub topic to notify once the job completes
   // TODO(developer): create a Pub/Sub topic to use for this

--- a/samples/inspectFile.js
+++ b/samples/inspectFile.js
@@ -56,7 +56,7 @@ function main(
 
   // The customInfoTypes of information to match
   // const customInfoTypes = [{ infoType: { name: 'DICT_TYPE' }, dictionary: { wordList: { words: ['foo', 'bar', 'baz']}}},
-  //   { infoType: { name: 'REGEX_TYPE' }, regex: '\\(\\d{3}\\) \\d{3}-\\d{4}'}];
+  //   { infoType: { name: 'REGEX_TYPE' }, regex: {pattern: '\\(\\d{3}\\) \\d{3}-\\d{4}'}}];
 
   // Whether to include the matching string
   // const includeQuote = true;

--- a/samples/inspectGCSFile.js
+++ b/samples/inspectGCSFile.js
@@ -60,7 +60,7 @@ function main(
 
   // The customInfoTypes of information to match
   // const customInfoTypes = [{ infoType: { name: 'DICT_TYPE' }, dictionary: { wordList: { words: ['foo', 'bar', 'baz']}}},
-  //   { infoType: { name: 'REGEX_TYPE' }, regex: '\\(\\d{3}\\) \\d{3}-\\d{4}'}];
+  //   { infoType: { name: 'REGEX_TYPE' }, regex: {pattern: '\\(\\d{3}\\) \\d{3}-\\d{4}'}}];
 
   // The name of the Pub/Sub topic to notify once the job completes
   // TODO(developer): create a Pub/Sub topic to use for this

--- a/samples/inspectString.js
+++ b/samples/inspectString.js
@@ -54,7 +54,7 @@ function main(
 
   // The customInfoTypes of information to match
   // const customInfoTypes = [{ infoType: { name: 'DICT_TYPE' }, dictionary: { wordList: { words: ['foo', 'bar', 'baz']}}},
-  //   { infoType: { name: 'REGEX_TYPE' }, regex: '\\(\\d{3}\\) \\d{3}-\\d{4}'}];
+  //   { infoType: { name: 'REGEX_TYPE' }, regex: {pattern: '\\(\\d{3}\\) \\d{3}-\\d{4}'}}];
 
   // Whether to include the matching string
   // const includeQuote = true;


### PR DESCRIPTION
Fixes #465 

@JustinBeckwith, I should have changed this documentation when I refactored the library (it was an oversight). These tests actually were a bit of work given this confusion, and I had to write a little helper function (`transformCLI`) in order to do the work that yargs was doing previously in manipulating the arguments into the right format. 

All that to say, can confirm that @mr-m0u5e's suggestion is correct