### PR TITLE
build: fix sample test

### DIFF
--- a/samples/system-test/deid.test.js
+++ b/samples/system-test/deid.test.js
@@ -53,18 +53,6 @@ describe('deid', () => {
     assert.include(output, harmlessString);
   });
 
-  it('should handle masking errors', () => {
-    let output;
-    try {
-      output = cp.execSync(
-        `node deidentifyWithMask.js ${projectId} "${harmfulString}" 'a' '-1'`
-      );
-    } catch (err) {
-      output = err.message;
-    }
-    assert.include(output, 'INVALID_ARGUMENT');
-  });
-
   // deidentify_fpe
   it('should handle FPE encryption errors', () => {
     let output;


### PR DESCRIPTION
Fixes #720 

I think it's safe to just delete this test. Turns out that the number to mask can be a negative number, and it seems that nothing really counts as an invalid argument for the request, and the harmful string is always successfully masked. So, I just think this is just a feature.
https://cloud.google.com/dlp/docs/reference/rest/v2/projects.deidentifyTemplates#DeidentifyTemplate.DeidentifyConfig